### PR TITLE
Some fixes

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -275,6 +275,9 @@ CServer::CServer() : m_Register(false), m_RegSixup(true)
 	m_pCurrentMapData = 0;
 	m_CurrentMapSize = 0;
 
+	m_pSixupMapData = 0;
+	m_SixupMapSize = 0;
+
 	m_MapReload = 0;
 	m_ReloadedWhenEmpty = false;
 
@@ -1919,7 +1922,6 @@ int CServer::LoadMap(const char *pMapName)
 	{
 		IOHANDLE File = SixupMap.File();
 		m_SixupMapSize = (unsigned int)io_length(File);
-		free(m_pSixupMapData);
 		m_pSixupMapData = (unsigned char *)malloc(m_SixupMapSize);
 		io_read(File, m_pSixupMapData, m_SixupMapSize);
 	}

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1922,6 +1922,7 @@ int CServer::LoadMap(const char *pMapName)
 	{
 		IOHANDLE File = SixupMap.File();
 		m_SixupMapSize = (unsigned int)io_length(File);
+		free(m_pSixupMapData);
 		m_pSixupMapData = (unsigned char *)malloc(m_SixupMapSize);
 		io_read(File, m_pSixupMapData, m_SixupMapSize);
 	}

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -361,7 +361,7 @@ MACRO_CONFIG_INT(SvRankCheats, sv_rank_cheats, 0, 0, 1, CFGFLAG_SERVER, "Enable 
 MACRO_CONFIG_INT(SvShutdownWhenEmpty, sv_shutdown_when_empty, 0, 0, 1, CFGFLAG_SERVER, "Shutdown server as soon as no one is on it anymore")
 MACRO_CONFIG_INT(SvReloadWhenEmpty, sv_reload_when_empty, 0, 0, 2, CFGFLAG_SERVER, "Reload map when server is empty (1 = reload once, 2 = reload every time server gets empty)")
 MACRO_CONFIG_INT(SvKillProtection, sv_kill_protection, 20, 0, 9999, CFGFLAG_SERVER, "0 - Disable, 1-9999 minutes")
-MACRO_CONFIG_INT(SvSoloServer, sv_solo_server, 0, 0, 1, CFGFLAG_SERVER|CFGFLAG_GAME, "Set server to solo mode (no player interactions, has to be set before loading the map)")
+MACRO_CONFIG_INT(SvSoloServer, sv_solo_server, 1, 0, 1, CFGFLAG_SERVER|CFGFLAG_GAME, "Set server to solo mode (no player interactions, has to be set before loading the map)")
 MACRO_CONFIG_STR(SvClientSuggestion, sv_client_suggestion, 128, "Get DDNet client from DDNet.tw to use all features on DDNet!", CFGFLAG_SERVER, "Broadcast to display to players without DDNet client")
 MACRO_CONFIG_STR(SvClientSuggestionOld, sv_client_suggestion_old, 128, "Your DDNet client is old, update it on DDNet.tw!", CFGFLAG_SERVER, "Broadcast to display to players with an old version of DDNet client")
 MACRO_CONFIG_STR(SvClientSuggestionBot, sv_client_suggestion_bot, 128, "Your client has bots and can be remotely controlled!\nPlease use another client like DDNet client from DDNet.tw", CFGFLAG_SERVER, "Broadcast to display to players with a known botting client")

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -1022,24 +1022,29 @@ void IGameController::UpdateRecordFlag()
 
 int IGameController::SnapRecordFlag(int SnappingClient)
 {
-	CCharacter *pRecordFlagChar = GameServer()->m_pController->m_pRecordFlagChar;
-	if(!pRecordFlagChar)
+	if (!m_pRecordFlagChar)
 		return FLAG_MISSING;
-	if(!GameServer()->m_apPlayers[SnappingClient]->m_ShowOthers && pRecordFlagChar->GetPlayer()->GetCID() != SnappingClient && GameServer()->m_apPlayers[SnappingClient]->GetTeam() != TEAM_SPECTATORS)
+
+	CPlayer *pRecordFlagCarrier = m_pRecordFlagChar->GetPlayer();
+	CPlayer* pSnapPlayer = GameServer()->m_apPlayers[SnappingClient];
+
+	if (pSnapPlayer->GetCharacter() && pSnapPlayer->GetCharacter()->NetworkClipped(SnappingClient, m_pRecordFlagChar->m_Pos))
 		return FLAG_MISSING;
-	if(pRecordFlagChar->GetPlayer()->GetCID() == SnappingClient && !pRecordFlagChar->GetPlayer()->m_ShowFlag)
+	if(!pSnapPlayer->m_ShowOthers && pRecordFlagCarrier->GetCID() != SnappingClient && pSnapPlayer->GetTeam() != TEAM_SPECTATORS)
 		return FLAG_MISSING;
-	if(pRecordFlagChar->GetPlayer()->GetCID() == SnappingClient && !pRecordFlagChar->GetPlayer()->m_ShowOthers && pRecordFlagChar->GetPlayer()->IsPaused() && pRecordFlagChar->GetPlayer()->m_SpectatorID != SPEC_FREEVIEW)
+	if(pRecordFlagCarrier->GetCID() == SnappingClient && !pRecordFlagCarrier->m_ShowFlag)
+		return FLAG_MISSING;
+	if(pRecordFlagCarrier->GetCID() == SnappingClient && !pRecordFlagCarrier->m_ShowOthers && pRecordFlagCarrier->IsPaused() && pRecordFlagCarrier->m_SpectatorID != SPEC_FREEVIEW)
 		return FLAG_MISSING;
 
 	CNetObj_Flag *pFlag = (CNetObj_Flag *)Server()->SnapNewItem(NETOBJTYPE_FLAG, TEAM_BLUE, sizeof(CNetObj_Flag));
 	if(!pFlag)
 		return FLAG_MISSING;
-	pFlag->m_X = (int)pRecordFlagChar->m_Pos.x;
-	pFlag->m_Y = (int)pRecordFlagChar->m_Pos.y;
+	pFlag->m_X = (int)m_pRecordFlagChar->m_Pos.x;
+	pFlag->m_Y = (int)m_pRecordFlagChar->m_Pos.y;
 	pFlag->m_Team = TEAM_BLUE;
 
-	return pRecordFlagChar->GetPlayer()->GetCID();
+	return pRecordFlagCarrier->GetCID();
 }
 
 int IGameController::SnapFastcapFlag(int SnappingClient)


### PR DESCRIPTION
Fixed crashing on Windows when Sixup map pointer is uninitialized;
Set `sv_solo_server 1` by default;
Fixed annoying (for me at least) flag snapping while flag carrier's character is out of view range.